### PR TITLE
French translation for Data Explorer v.2

### DIFF
--- a/src/assets/i18n/Français.json
+++ b/src/assets/i18n/Français.json
@@ -20,7 +20,7 @@
   "VAR": {
     "SEARCH": "Chercher",
     "SELECT": "Sélectionner",
-    "DESELECT": "Désélectionner"
+    "DESELECT": "Désélectionner",
     "ID": "ID",
     "NAME": "Nom",
     "LABEL": "Libellé",

--- a/src/assets/i18n/Français.json
+++ b/src/assets/i18n/Français.json
@@ -20,6 +20,7 @@
   "VAR": {
     "SEARCH": "Chercher",
     "SELECT": "Sélectionner",
+    "DESELECT": "Désélectionner"
     "ID": "ID",
     "NAME": "Nom",
     "LABEL": "Libellé",

--- a/src/assets/i18n/Français.json
+++ b/src/assets/i18n/Français.json
@@ -1,6 +1,6 @@
 {
   "INTERFACE": {
-    "LANG": "Language FR"
+    "LANG": "Langue"
   },
   "GROUPS": {
     "HIDE": "Masquer les groupes",
@@ -10,35 +10,35 @@
   "SAVE": {
     "DOWNLOAD": "Télécharger",
     "DOWNLOADSUB": "Télécharger le sous-ensemble",
-    "DOWNLOADORIG": "Fichier au format d'origine",
-    "DOWNLOADTAB": "Fichier délimité par des tabulations",
-    "DOWNLOADRDATA": "Fichier au format RData",
-    "DOWNLOADVARMETA": "Métadonnées des variables",
-    "NOFILEID": "Cannot download, there is no file id FR",
-    "NOSELECT": "There was no selection FR"
+    "DOWNLOADORIG": "Télécharger le fichier en format original",
+    "DOWNLOADTAB": "Télécharger le fichier délimité par des tabulations",
+    "DOWNLOADRDATA": "Télécharger le fichier en format RData",
+    "DOWNLOADVARMETA": "Télécharger les métadonnées des variables",
+    "NOFILEID": "Téléchargement impossible, il n'y a pas d'identifiant de fichier",
+    "NOSELECT": "Aucune sélection n'a été faite"
   },
   "VAR": {
     "SEARCH": "Chercher",
     "SELECT": "Sélectionner",
     "ID": "ID",
     "NAME": "Nom",
-    "LABEL": "Étiquette",
+    "LABEL": "Libellé",
     "WEIGHT": "Poids",
-    "VIEW": "Visualiser FR",
-    "VIEWQUEST": "View Questions FR",
-    "VIEWSUMSTAT": "View Summary Statistics FR"
+    "VIEW": "Afficher les catégories",
+    "VIEWQUEST": "Afficher les questions",
+    "VIEWSUMSTAT": "Afficher les statistiques sommaires"
   },
   "VARDIALOG":{
     "VARINFO": "Information sur la variable",
     "LITQ": "Question littérale",
-    "INTINSTR": "Les directives pour l'intervieweur",
-    "POSTQ": "Instruction à propos de la question posée",
+    "INTINSTR": "Directives d'entrevue",
+    "POSTQ": "Instructions à propos de la question posée",
     "UNIVERSE": "Univers",
     "NOTES" : "Remarques",
     "GROUP" : "Groupe",
-    "WEIGHTVAR": "Variable de poids",
-    "UNWEIGHTED": "Non-pondéré",
-    "ISWEIGHT": "Pondéré",
+    "WEIGHTVAR": "Variable de pondération",
+    "UNWEIGHTED": "Non-pondéré(e)",
+    "ISWEIGHT": "Pondéré(e)",
     "UPDATE": "Mettre à jour",
     "CANCEL": "Annuler"
   },
@@ -48,19 +48,19 @@
     "CATEGORIES": "Catégories",
     "COUNT": "Nombre",
     "COUNTPER": "Nombre d'observations en %",
-    "WEIGHTCOUNT": "Chiffre pondéré",
-    "MEDIAN": "Median FR",
-    "STDEV": "Standard deviation FR",
-    "MIN": "Minimum FR",
-    "MAX": "Maximum FR",
-    "MEAN": "Mean FR",
-    "VALD": "Total Valid Count FR",
-    "INVD": "Total Invalid Count FR",
-    "OTHER": "Other FR",
-    "SUMMARYSTAT": "Summary Statistics FR",
-    "SELVARNOTE": "There are no variables FR",
-    "CROSSTAB": "Cross Tabulation FR",
-    "NOCATEGORIES": "This variable does not have any categories assigned FR"
+    "WEIGHTCOUNT": "Nombre d'observations (pondéré)",
+    "MEDIAN": "Médiane",
+    "STDEV": "Écart type",
+    "MIN": "Minimum",
+    "MAX": "Maximum",
+    "MEAN": "Moyenne",
+    "VALD": "Nombre d'observations valides",
+    "INVD": "Nombre d'observations manquantes",
+    "OTHER": "Autre",
+    "SUMMARYSTAT": "Statistiques sommaires",
+    "SELVARNOTE": "Il n'y a pas de variables",
+    "CROSSTAB": "Tableau croisé",
+    "NOCATEGORIES": "Variable sans catégorie attribuée"
   },
   "PAGINATOR": {
     "ITEMS_PER_PAGE": "Éléments par page",
@@ -69,18 +69,18 @@
     "RANGE": "{{startIndex}} - {{endIndex}} de {{length}}"
   },
   "CROSSTAB": {
-    "TABLE": "Cross Tabulation Table FR",
-    "VARS": "Select Variables {{group}} For Cross Tabulation FR",
+    "TABLE": "Tableau croisé",
+    "VARS": "Sélectionner les variables {{group}} pour le tableau croisé",
     "ALLVAR": "Toutes les variables",
-    "ROWS": "Rows FR",
-    "COLUMNS": "Columns FR",
-    "TOTAL": "Total FR",
-    "DATAVERSE": "Data Explorer is not connected to Dataverse FR",
-    "TOOMANYVAR": "Too many selected variables. Please select not more than {{length}} variables FR",
-    "OK": "OK FR",
-    "MOVETOROWS": "Move to Rows FR",
-    "MOVETOCOLS": "Move to Columns FR",
-    "REMOVEFROMROWS": "Remove from Rows FR",
-    "REMOVEFROMCOLS": "Remove from Columns FR"
+    "ROWS": "Lignes",
+    "COLUMNS": "Colonnes",
+    "TOTAL": "Total",
+    "DATAVERSE": "L'outil Data Explorer n'est pas connecté à Dataverse",
+    "TOOMANYVAR": "Le nombre de variables sélectionnées est trop grand. Ne pas sélectionner plus de {{length}} variable(s)",
+    "OK": "Ok",
+    "MOVETOROWS": "Déplacer vers les lignes",
+    "MOVETOCOLS": "Déplacer vers les colonnes",
+    "REMOVEFROMROWS": "Retirer des lignes",
+    "REMOVEFROMCOLS": "Retirer des colonnes"
   }
 }


### PR DESCRIPTION
Hi @kaitlinnewson,

Here is the revised French translation. Thanks to Jonathan Dorey for double checking.

---

There seem to be inconsistencies with how the "Data Explorer" is used in the French documentation. 

Here it is translated as "explorateur de données": 

_« Utiliser l’explorateur de données »_   (https://learn.scholarsportal.info/fr/guides/dataverse/trouver-et-utiliser-des-donnees/) 

And here  "l'outil Data Explorer" is used (https://dataverse.scholarsportal.info/fr/):

_«  L’outil Dataverse Data Explorer supporte les formats de fichiers les plus répandus compatibles avec Stata, SPSS, R et Microsoft Excel (incluant les fichiers CSV). »_
and
_« L’outil Data Explorer est accessible dans Dataverse pour les fichiers de données tabulaires.»_

Same for the display in the Data Explorer v1. (or never translated in the first place):

![image](https://user-images.githubusercontent.com/10760472/97501685-17a59780-1948-11eb-83a6-e62526029741.png)







So for now I went with "L'outil Data Explorer n'est pas connecté à Dataverse" in the `Français.json` file. You might want to see if you want to keep the brand name "Data Explorer" as such or if you want to translate it; in which case I recommend the use of the capital letter to indicate the name of the product : "L'**E**xplorateur de données n'est pas connecté à Dataverse" (instead of "**e**xplorateur de données"). 


