### PR TITLE
Keyboard tabbing for groups

### DIFF
--- a/src/app/select-vars-dialog/select-vars-dialog.component.html
+++ b/src/app/select-vars-dialog/select-vars-dialog.component.html
@@ -7,8 +7,8 @@
     <mat-grid-tile [rowspan]=2 colspan='2'>
       <mat-selection-list #list class="mat-selection-list-big" [(ngModel)]="selectedOptions" (ngModelChange)="onSelectOrDeselectVar($event)">
         <h3 matSubheader>{{'CROSSTAB.ALLVAR' | translate}}</h3>
-        <mat-list-option [value]='variable' *ngFor="let variable of variablesToSelect"  >
-          <a mat-list-item> <span>{{ variable["@shortname"]}} - {{variable.labl['#text'].substring(0,45)}}</span> </a>
+        <mat-list-option [value]='variable' *ngFor="let variable of variablesToSelect">
+          {{ variable["@shortname"]}} - {{variable.labl['#text'].substring(0,45)}}
         </mat-list-option>
       </mat-selection-list>
     </mat-grid-tile>
@@ -25,7 +25,7 @@
       <mat-selection-list #varCol class="mat-selection-list-small"   [(ngModel)]="selectedOptionsRow" (ngModelChange)="onSelectOrDeselectRow($event)">
         <h3 matSubheader>{{'CROSSTAB.ROWS' | translate}}</h3>
         <mat-list-option [value]='variable' *ngFor="let variable of selectedVarsRow" >
-          <a mat-list-item> <span>{{ variable["@shortname"]}} - {{variable.labl['#text'].substring(0,45)}}</span> </a>
+          {{ variable["@shortname"]}} - {{variable.labl['#text'].substring(0,45)}}
         </mat-list-option>
       </mat-selection-list>
     </mat-grid-tile>

--- a/src/app/var-group/var-group.component.html
+++ b/src/app/var-group/var-group.component.html
@@ -1,10 +1,11 @@
 <mat-nav-list class="groups-list">
 
   <mat-divider></mat-divider>
-  <a mat-list-item (click)="showAll()" [ngClass]="{'active': allActive }">{{'GROUPS.ALLVAR' | translate}}</a>
+  <a mat-list-item href="" (click)="showAll()" [ngClass]="{'active': allActive }">{{'GROUPS.ALLVAR' | translate}}</a>
   <mat-divider></mat-divider>
   <a mat-list-item
      id="{{tab.varGrp['@ID']}}"
+     href=""
      [disableRipple]="true"
      *ngFor="let tab of variableGroups"
      (click)="onGroupClick(tab)"

--- a/src/app/var-group/var-group.component.ts
+++ b/src/app/var-group/var-group.component.ts
@@ -30,6 +30,7 @@ export class VarGroupComponent implements OnInit {
     this.allActive = true;
     this.subSetRows.emit();
     this.selection.clear();
+    return false;
   }
   onGroupClick(_obj) {
     this.ddiService.clearSearch();
@@ -39,6 +40,7 @@ export class VarGroupComponent implements OnInit {
     this.subSetRows.emit(vars);
     this.showActive(obj.varGrp['@ID']);
     this.selection.clear();
+    return false;
   }
 
   showActive(_id?) {


### PR DESCRIPTION
Fixes issue which does not allow for keyboard navigation to the groups panel. Also removes `<a>` elements in crosstab panel as those are not links.